### PR TITLE
Date now converts to overridden type

### DIFF
--- a/lib/typson-schema.js
+++ b/lib/typson-schema.js
@@ -33,6 +33,7 @@ var TypeScript, _, traverse; // from global scope
     }
     var api = {};
     var primitiveTypes = [ "string", "number", "boolean", "any" ];
+    var overriddenTypes = [ "Date" ];
     var validationKeywords = [ "type", "minimum", "exclusiveMinimum", "maximum", "exclusiveMaximum", "multipleOf", "minLength", "maxLength", "format", "pattern", "minItems", "maxItems", "uniqueItems", "default", "additionalProperties" ];
     var annotedValidationKeywordPattern = /@[a-z.]+\s*[^@\s]+/gi;
     var TypescriptASTFlags = { "optionalName" : 4, "arrayType" : 8 };
@@ -149,7 +150,7 @@ var TypeScript, _, traverse; // from global scope
         _.each(type.members.members, function (variable) {
             var property = definition.properties[variable.id.actualText] = {};
             copyComment(variable, property);
-            var overridenType = property.type;
+            var overriddenType = property.type;
             var variableType = extractFullTypeName(variable.typeExpr.term);
             var propertyType = null;
 
@@ -209,10 +210,14 @@ var TypeScript, _, traverse; // from global scope
             } 
             //other
             else if (primitiveTypes.indexOf(variableType) === -1) {
-                propertyType.$ref = refPath? refPath+"/"+fullTypeName: fullTypeName;
+                if (overriddenTypes.indexOf(variableType) >= 0 && overriddenType) {
+                    propertyType.type = overriddenType;
+                } else {
+                    propertyType.$ref = refPath? refPath+"/"+fullTypeName: fullTypeName;
+                }
             } else {
                 if(variableType !== "any") {
-                    propertyType.type = overridenType || variableType;
+                    propertyType.type = overriddenType || variableType;
                 }
             }
         });

--- a/lib/typson-schema.js
+++ b/lib/typson-schema.js
@@ -33,7 +33,7 @@ var TypeScript, _, traverse; // from global scope
     }
     var api = {};
     var primitiveTypes = [ "string", "number", "boolean", "any" ];
-    var overriddenTypes = [ "Date" ];
+    var overriddenTypes = [ "Date", "Buffer" ];
     var validationKeywords = [ "type", "minimum", "exclusiveMinimum", "maximum", "exclusiveMaximum", "multipleOf", "minLength", "maxLength", "format", "pattern", "minItems", "maxItems", "uniqueItems", "default", "additionalProperties" ];
     var annotedValidationKeywordPattern = /@[a-z.]+\s*[^@\s]+/gi;
     var TypescriptASTFlags = { "optionalName" : 4, "arrayType" : 8 };


### PR DESCRIPTION
Also, fixed spelling of overriden -> overridden

An alternative to this would be just to bypass `$ref` whenever there is an overridden type.

It still throws the error. It happens at:
https://github.com/lbovet/typson/blob/master/lib/typson.js#L86

Not sure what solution should be used to silence the error. Could check if the value in `semanticDiagnostics` is in the array `overriddenTypes`. But I would need to create a new file that both files can call. Of course, we could just let the error pass through, just annoying though when a person is using error checking.

fixes #16
